### PR TITLE
RRO: idmap: fix sorting of overlays.list

### DIFF
--- a/cmds/idmap/scan.cpp
+++ b/cmds/idmap/scan.cpp
@@ -23,8 +23,7 @@ namespace {
 
         bool operator<(Overlay const& rhs) const
         {
-            // Note: order is reversed by design
-            return rhs.priority < priority;
+            return rhs.priority > priority;
         }
 
         String8 apk_path;


### PR DESCRIPTION
Multiple overlay packages with targetPackage="android" are loaded in the
wrong order due to the incorrect order they are listed in overlays.list.
This will cause runtime resource overlay to fail when multiple overlay
packages target the same resources in framework-res.apk.

Correct the order in which overlays are loaded by changing the sorting
of overlays.list.

Background: commit f90f2f8d changed the order in which overlay packages
should be added to ResTables. The expected order is now in ascending
priority. This must be reflected in overlays.list.

Change-Id: I249984c0e34b6009e7280ce2777750c76ab16e37