### PR TITLE
SlimDoze: Fix gesture triggers not following Ambient display

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/doze/DozeService.java
+++ b/packages/SystemUI/src/com/android/systemui/doze/DozeService.java
@@ -349,18 +349,18 @@ public class DozeService extends DreamService {
             }
             s.setListening(listen);
         }
-        if (mDozeTriggerTilt) {
+        if (mDozeTriggerTilt && listen) {
             mTiltSensor.enable();
         } else {
             mTiltSensor.disable();
         }
-        if (mDozeTriggerHandWave || mDozeTriggerPocket) {
+        if ((mDozeTriggerHandWave || mDozeTriggerPocket) && listen) {
             mProximitySensor.enable();
         } else {
             mProximitySensor.disable();
         }
         listenForBroadcasts(listen);
-        if (mDozeTriggerNotification) {
+        if (mDozeTriggerNotification && listen) {
             listenForNotifications(listen);
         }
     }


### PR DESCRIPTION
When Ambient display was switched off, the gesture and notification triggers
were still active.  Adding the listen parameter to the trigger checks prevents this.
Thanks to Jean-Pierre Rasquin for the insight.

Change-Id: I051ddc23c00a1fe8fbcc0726e7c7cfe5de355708